### PR TITLE
fix(cli): Allow negative values for cpu and mem

### DIFF
--- a/skrooge/cli.py
+++ b/skrooge/cli.py
@@ -146,8 +146,8 @@ def estimate(replicas, cpu, mem, instance, cost_class, region, format):
             f"{instance} not found. Did you mean: {', '.join(close_matches)}\nMissing an instance type that exists? {missing_instance_type_link}"
         )
 
-    delta_cpu = replicas * cpu
-    delta_mem = replicas * mem
+    delta_cpu = replicas * abs(cpu)
+    delta_mem = replicas * abs(mem)
 
     logger.info(f"{delta_cpu=}m {delta_mem=}MiB")
 

--- a/skrooge/utils.py
+++ b/skrooge/utils.py
@@ -6,10 +6,9 @@ def determine_constrained_resource(instance_data, cpu, mem):
     logging.info(
         f"Calculating constrained resource: {instance_data['specs']=}, {cpu=}, {mem=}"
     )
-    if (
-        instance_data["specs"]["cores"] * 1000 / abs(cpu)
-        > instance_data["specs"]["memory"] * 1024 / abs(mem)
-    ):
+    if instance_data["specs"]["cores"] * 1000 / abs(cpu) > instance_data["specs"][
+        "memory"
+    ] * 1024 / abs(mem):
         return "memory"
     else:
         return "cores"

--- a/skrooge/utils.py
+++ b/skrooge/utils.py
@@ -7,8 +7,8 @@ def determine_constrained_resource(instance_data, cpu, mem):
         f"Calculating constrained resource: {instance_data['specs']=}, {cpu=}, {mem=}"
     )
     if (
-        instance_data["specs"]["cores"] * 1000 / cpu
-        > instance_data["specs"]["memory"] * 1024 / mem
+        instance_data["specs"]["cores"] * 1000 / abs(cpu)
+        > instance_data["specs"]["memory"] * 1024 / abs(mem)
     ):
         return "memory"
     else:

--- a/tests/test_skrooge.py
+++ b/tests/test_skrooge.py
@@ -30,3 +30,19 @@ def test_invalid_instance_type_provides_github_bug_report_link():
             "https://github.com/getsentry/skrooge/issues/new?assignees=&labels=&projects=&template=BUG_REPORT.md"
             in result.output
         )
+
+
+def test_treat_negative_cpu_and_mem_values_as_absolute():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["estimate", "--instance", "n2-standard-32", "--replicas", 30, "--cpu", -2500, "--mem", -2024])
+        assert result.exit_code == 0
+
+        # whitespace prefix to check non-negative
+        assert " 75.0" in result.output
+        assert " 59.296875" in result.output
+        assert "cores-constrained" in result.output
+        assert "require 3 instances" in result.output
+        assert "$3.73/h" in result.output
+        assert "$2722/m" in result.output
+        assert "$32669/y" in result.output

--- a/tests/test_skrooge.py
+++ b/tests/test_skrooge.py
@@ -35,7 +35,20 @@ def test_invalid_instance_type_provides_github_bug_report_link():
 def test_treat_negative_cpu_and_mem_values_as_absolute():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["estimate", "--instance", "n2-standard-32", "--replicas", 30, "--cpu", -2500, "--mem", -2024])
+        result = runner.invoke(
+            cli,
+            [
+                "estimate",
+                "--instance",
+                "n2-standard-32",
+                "--replicas",
+                30,
+                "--cpu",
+                -2500,
+                "--mem",
+                -2024,
+            ],
+        )
         assert result.exit_code == 0
 
         # whitespace prefix to check non-negative

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -321,11 +321,15 @@ def test_determine_constrained_resource_mem_bound():
         == "memory"
     )
 
+
 def test_determine_constrained_resource_normalize_negative_values_as_absolutes():
     assert (
-        determine_constrained_resource(c2_standard_30_instance_data, cpu=-10000, mem=-128)
+        determine_constrained_resource(
+            c2_standard_30_instance_data, cpu=-10000, mem=-128
+        )
         == "cores"
     )
+
 
 def test_determine_instance_count_required_minimum_of_one_cpu():
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -321,6 +321,11 @@ def test_determine_constrained_resource_mem_bound():
         == "memory"
     )
 
+def test_determine_constrained_resource_normalize_negative_values_as_absolutes():
+    assert (
+        determine_constrained_resource(c2_standard_30_instance_data, cpu=-10000, mem=-128)
+        == "cores"
+    )
 
 def test_determine_instance_count_required_minimum_of_one_cpu():
     assert (


### PR DESCRIPTION
Fixes #6 

### Changes:

- Use the absolute values of cpu and mem for all calculations

- [x] Tests added